### PR TITLE
feat(#6): add uri config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,17 @@ export default defineNuxtConfig({
   // required
   defaultLocale: string;
 
-  // Can be used to filter out stories by full_slug via RegExp
+  // can be used to filter out stories by full_slug via RegExp
   // optional, default []
   blacklist: string[];
 
   // Storyblok API url
   // optional, default "https://api.storyblok.com/v2/cdn/stories"
   apiUrl: string;
+
+  // path to the sitemap file, relative to the website domain
+  // optional, default "sitemap.xml"
+  uri: string;
 }
 ```
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,6 +19,7 @@ export interface ModuleOptions {
   defaultLocale?: string;
   blacklist: string[];
   apiUrl: string;
+  uri: string;
 }
 
 export interface ModulePrivateRuntimeConfig {
@@ -45,6 +46,7 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     blacklist: [],
     apiUrl: "https://api.storyblok.com/v2/cdn/stories",
+    uri: "sitemap.xml",
   },
   async setup(options, nuxt) {
     if (!options.accessToken) {
@@ -75,7 +77,7 @@ export default defineNuxtModule<ModuleOptions>({
     };
 
     addServerHandler({
-      route: "/sitemap.xml",
+      route: `/${options.uri}`,
       handler: resolver.resolve("./runtime/handler"),
     });
   },


### PR DESCRIPTION
This PR adds an `uri` config parameter that can be used to define the sitemap path (relative to the website domain).
closes #6 