### PR TITLE
chore(#3): improve cache

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   modules: ["../src/module"],
   storyblokSitemap: {
-    accessToken: "abc",
+    accessToken: "",
     baseUrl: "https://google.com",
     defaultLocale: "en",
     blacklist: ["^global/", "^page-not-found$", "^job/"],

--- a/src/module.ts
+++ b/src/module.ts
@@ -82,3 +82,9 @@ export default defineNuxtModule<ModuleOptions>({
     });
   },
 });
+
+declare module "@nuxt/schema" {
+  interface RuntimeConfig {
+    [configKey]: ModulePrivateRuntimeConfig;
+  }
+}

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   modules: ["../../../src/module"],
   storyblokSitemap: {
-    accessToken: "abc",
+    accessToken: "",
     baseUrl: "https://google.com",
     defaultLocale: "en",
   },


### PR DESCRIPTION
resolves #3 
This PR improves caching strategy of fetching stories.
First request does the "cache miss" intentionally to get the most recent cached timestamp from the response (see https://www.storyblok.com/docs/api/content-delivery/v2#topics/cache-invalidation). All the following requests (within the same sitemap request) will take advantage of the "cache hit".